### PR TITLE
fix api key encrypt - decrypt issue

### DIFF
--- a/src/crud/api_key.py
+++ b/src/crud/api_key.py
@@ -71,9 +71,9 @@ async def create_api_key(db: AsyncSession, user_id: int, api_key_in: APIKeyCreat
     # Hash the API key (keep for backward compatibility)
     hashed_key = get_api_key_hash(full_key)
 
-    # Encrypt the API key using Cognito user data
+    # Encrypt the API key using Cognito user ID
     encrypted_key = APIKeyEncryption.encrypt_api_key(
-        full_key, user.cognito_user_id, user.email
+        full_key, user.cognito_user_id
     )
     
     # Create API key object with required fields
@@ -84,8 +84,6 @@ async def create_api_key(db: AsyncSession, user_id: int, api_key_in: APIKeyCreat
         "encryption_version": 1,
         "user_id": user_id,
         "is_active": True,
-        "encrypted_key": encrypted_key,
-        "encryption_version": 1,
     }
     
     # Add optional name field if provided
@@ -291,102 +289,7 @@ async def delete_all_user_api_keys(db: AsyncSession, user_id: int) -> int:
     )
     await db.commit()
     
-    return count 
-
-async def get_default_api_key(db: AsyncSession, user_id: int) -> Optional[APIKey]:
-    """
-    Get the user's default API key. If no default is set, returns the first (oldest) active API key.
-    
-    Args:
-        db: Database session
-        user_id: User ID
-        
-    Returns:
-        Default APIKey object if found, None otherwise
-    """
-    # First, try to get the user-defined default key
-    result = await db.execute(
-        select(APIKey)
-        .options(joinedload(APIKey.user))
-        .where(APIKey.user_id == user_id)
-        .where(APIKey.is_active == True)
-        .where(APIKey.is_default == True)
-        .limit(1)
-    )
-    default_key = result.scalars().first()
-    
-    if default_key:
-        return default_key
-    
-    # If no default is set, fall back to the first (oldest) active key
-    result = await db.execute(
-        select(APIKey)
-        .options(joinedload(APIKey.user))
-        .where(APIKey.user_id == user_id)
-        .where(APIKey.is_active == True)
-        .order_by(APIKey.created_at.asc())
-        .limit(1)
-    )
-    return result.scalars().first()
-
-async def get_first_active_api_key(db: AsyncSession, user_id: int) -> Optional[APIKey]:
-    """
-    Get the first (oldest) active API key for a user.
-    
-    Args:
-        db: Database session
-        user_id: User ID
-        
-    Returns:
-        First active APIKey object if found, None otherwise
-    """
-    result = await db.execute(
-        select(APIKey)
-        .options(joinedload(APIKey.user))
-        .where(APIKey.user_id == user_id)
-        .where(APIKey.is_active == True)
-        .order_by(APIKey.created_at.asc())
-        .limit(1)
-    )
-    return result.scalars().first()
-
-async def set_default_api_key(db: AsyncSession, api_key_id: int, user_id: int) -> Optional[APIKey]:
-    """
-    Set an API key as the user's default. Clears any existing default.
-    
-    Args:
-        db: Database session
-        api_key_id: API key ID to set as default
-        user_id: User ID for security check
-        
-    Returns:
-        Updated APIKey object if successful, None otherwise
-    """
-    # First, clear any existing default for this user
-    await db.execute(
-        update(APIKey)
-        .where(APIKey.user_id == user_id)
-        .where(APIKey.is_default == True)
-        .values(is_default=False)
-    )
-    
-    # Set the new default
-    result = await db.execute(
-        update(APIKey)
-        .where(APIKey.id == api_key_id)
-        .where(APIKey.user_id == user_id)
-        .where(APIKey.is_active == True)
-        .values(is_default=True)
-        .returning(APIKey)
-    )
-    
-    updated_key = result.scalars().first()
-    if updated_key:
-        await db.commit()
-        await db.refresh(updated_key)
-        return updated_key
-    
-    return None
+    return count
 
 async def get_decrypted_api_key(db: AsyncSession, api_key_id: int, user_id: int) -> Optional[str]:
     """
@@ -400,6 +303,14 @@ async def get_decrypted_api_key(db: AsyncSession, api_key_id: int, user_id: int)
     Returns:
         Decrypted API key or None if not found/decryption fails
     """
+    from src.core.logging_config import get_auth_logger
+    logger = get_auth_logger()
+    
+    logger.debug("Getting decrypted API key", 
+                api_key_id=api_key_id,
+                user_id=user_id,
+                event_type="get_decrypted_api_key_start")
+    
     # Get API key with user info
     result = await db.execute(
         select(APIKey)
@@ -408,19 +319,48 @@ async def get_decrypted_api_key(db: AsyncSession, api_key_id: int, user_id: int)
     )
     api_key = result.scalar_one_or_none()
     
-    if not api_key or not api_key.encrypted_key:
+    if not api_key:
+        logger.warning("API key not found or not active", 
+                      api_key_id=api_key_id,
+                      user_id=user_id,
+                      event_type="api_key_not_found")
         return None
     
-    # Decrypt using user's Cognito data
+    if not api_key.encrypted_key:
+        logger.warning("API key has no encrypted data", 
+                      api_key_id=api_key_id,
+                      user_id=user_id,
+                      event_type="no_encrypted_data")
+        return None
+    
+    logger.debug("API key found, attempting decryption", 
+                api_key_id=api_key_id,
+                user_id=user_id,
+                cognito_user_id=api_key.user.cognito_user_id[:8] + "...",
+                user_email=api_key.user.email,
+                encrypted_key_length=len(api_key.encrypted_key),
+                event_type="api_key_found")
+    
+    # Decrypt using user's Cognito ID
     decrypted_key = APIKeyEncryption.decrypt_api_key(
         api_key.encrypted_key,
-        api_key.user.cognito_user_id,
-        api_key.user.email
+        api_key.user.cognito_user_id
     )
+    
+    if decrypted_key:
+        logger.debug("API key decryption successful", 
+                    api_key_id=api_key_id,
+                    user_id=user_id,
+                    event_type="decryption_successful")
+    else:
+        logger.error("API key decryption failed", 
+                    api_key_id=api_key_id,
+                    user_id=user_id,
+                    event_type="decryption_failed")
     
     return decrypted_key
 
-async def get_decrypted_default_api_key(db: AsyncSession, user_id: int) -> Optional[tuple[APIKey, str]]:
+async def get_decrypted_default_api_key(db: AsyncSession, user_id: int) -> tuple[Optional[APIKey], Optional[str], str]:
     """
     Get the user's default API key with decrypted full key.
     
@@ -429,18 +369,48 @@ async def get_decrypted_default_api_key(db: AsyncSession, user_id: int) -> Optio
         user_id: User ID
         
     Returns:
-        Tuple of (APIKey object, decrypted full key) or None if not found
+        Tuple of (APIKey object, decrypted full key, status_message)
+        - If successful: (APIKey, decrypted_key, "success")
+        - If no key found: (None, None, "no_key_found")
+        - If decryption failed: (APIKey, None, "decryption_failed")
     """
+    from src.core.logging_config import get_auth_logger
+    logger = get_auth_logger()
+    
+    logger.debug("Getting decrypted default API key", 
+                user_id=user_id,
+                event_type="get_decrypted_default_start")
+    
     # Get default API key or first active key
     default_api_key = await get_default_api_key(db, user_id)
     
     if not default_api_key:
-        return None
+        logger.warning("No default API key found for user", 
+                      user_id=user_id,
+                      event_type="no_default_key_found")
+        return None, None, "no_key_found"
+    
+    logger.debug("Default API key found, attempting decryption", 
+                user_id=user_id,
+                api_key_id=default_api_key.id,
+                key_prefix=default_api_key.key_prefix,
+                event_type="default_key_found")
     
     # Decrypt the full key
     decrypted_key = await get_decrypted_api_key(db, default_api_key.id, user_id)
     
     if not decrypted_key:
-        return None
+        logger.error("API key decryption failed for default key", 
+                    user_id=user_id,
+                    api_key_id=default_api_key.id,
+                    key_prefix=default_api_key.key_prefix,
+                    event_type="default_key_decryption_failed")
+        return default_api_key, None, "decryption_failed"
     
-    return default_api_key, decrypted_key 
+    logger.debug("Default API key decryption successful", 
+                user_id=user_id,
+                api_key_id=default_api_key.id,
+                key_prefix=default_api_key.key_prefix,
+                event_type="default_key_decryption_success")
+    
+    return default_api_key, decrypted_key, "success" 


### PR DESCRIPTION
Issue was that when user logs in via Oauth2 (either swagger or openbeta) for the first time, the users' email is not downloaded from cognito and stored in the database.  
API Key encryption was a combination of email + cognitoID + masterkey ... 
Email is originally the same as cognitoID until someone refreshes it from /auth/me and pulls that info thus rendering the decrypt key invalid 
Changes: 
* get_default_user method will now download latest email from cognito and update the database 
* api key encrypt / decrypt will be a combination of cognitoID and masterkey 
* removed the "refresh_from_cognito" option from auth/me as it should already be updated on user auth
* removed 3 duplicate methods (they were identical, but unncessary) 